### PR TITLE
Add android tools ignore MissingTranslation if file path contains don…

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -182,7 +182,11 @@ module Twine
       end
 
       def format_sections(twine_file, lang)
-        result = '<resources>'
+        if @options[:output_path].include? "donottranslate"
+          result = '<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">'
+        else 
+          result = '<resources>'
+        end
 
         result += super + "\n"
 
@@ -203,7 +207,7 @@ module Twine
           if section.is_uncategorized
             definitions.map! do |definition|
               # Only output definitions that are in the correct language
-              if definition.translation_for_lang_or_nil(lang, @twine_file.language_codes[0])
+              if definition.translation_for_lang_or_nil(lang, @options[:developer_language] || @twine_file.language_codes[0])
                 format_definition(definition, lang)
               end
             end

--- a/twine.iml
+++ b/twine.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/twine.iml
+++ b/twine.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
Fix read of devlopper language
When the output file path contains "donottranslate" the generated file will have the tools:ignore MissingTranslation flag