### PR TITLE
Ruby 2.5+ compatibility

### DIFF
--- a/twine
+++ b/twine
@@ -1,3 +1,3 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
-ruby -rubygems -I $BASEDIR/lib $BASEDIR/bin/twine $@
+ruby -rrubygems -I $BASEDIR/lib $BASEDIR/bin/twine $@


### PR DESCRIPTION
## Description

When used with Ruby 2.5+ twine fails because `rubygems` are deprecated since 2.5:
```
❯ ./twine --help
Traceback (most recent call last):
    1: from /Users/bartoszlipinski/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/Users/bartoszlipinski/.rvm/rubies/ruby-2.6.3/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- ubygems (LoadError)
```

## To Test

Backward compatibility:
1. Verify your Ruby is <2.5
2. Install twine from this branch
3. Run `twine --help` and see if it's successful