### PR TITLE
bug/fix Plurals

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -217,7 +217,6 @@ module Twine
           else
             # If the plural section has no definitions in this language, skip it
             # Otherwise, only output the correct definitions of the correct language
-            definitions.delete_if { |definition| definition.translation_for_lang_or_nil(lang, @twine_file.language_codes[0]).nil? }
 
             if !definitions.empty?
               result +=  plurals_start_key_value_pattern % { key:section.name }


### PR DESCRIPTION
# Description 
if some plural in non-english language was exactly the same as in english, it would be removed from the translation:
source file:
https://github.com/thefabulous/fabulous-core/blob/b528c307b59e508ed9f53e930df3f04cf918ecc4/strings/strings_android.txt#L52
output xml:
https://github.com/thefabulous/fabulous-android/blob/b8d4fa864e913922d8ddbc04bb1df550e51b364b/fabulous-android/src/main/res/values-fr/strings_android.xml#L21-L24

the original intention is not clear, but removing the single line from code seems to fix the issue

# Test
- use the exact source file linked in PR description, where `minute__other` is the same for `en` and `fr`
- run locally the translation script with current `master` version
- you can commit the changes to all the generated xml files
- checkout locally changes from this PR
- run the script 
- [x] the only change to string xml files is adding missing translation `<item quantity="other">%d minutes</item>`