### PR TITLE
bug/reverted twine version so that it doesn't cause massive changeset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 *.lock
 .DS_Store
+vendor/

--- a/lib/twine/version.rb
+++ b/lib/twine/version.rb
@@ -1,3 +1,3 @@
 module Twine
-    VERSION = '0.9.2.fab'
+    VERSION = '0.9.1.fab'
 end


### PR DESCRIPTION

We should only increase the version if we want to make sure the files are regenerated and the old old version should never be used. 

Reverting previous version bump